### PR TITLE
Fixed Door class attempting to load without MalisisDoors present

### DIFF
--- a/src/main/java/com/github/abrarsyed/secretroomsmod/common/SecretRooms.java
+++ b/src/main/java/com/github/abrarsyed/secretroomsmod/common/SecretRooms.java
@@ -39,6 +39,7 @@ import com.github.abrarsyed.secretroomsmod.items.ItemCamoDoor;
 import com.github.abrarsyed.secretroomsmod.malisisdoors.MalisisDoorsCompat;
 import com.github.abrarsyed.secretroomsmod.network.PacketManager;
 
+import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.Mod;
 import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.Mod.Instance;
@@ -144,12 +145,12 @@ public class SecretRooms
         camoGate = new BlockCamoGate().setBlockName("CamoGate");
         camoGateExt = new BlockCamoDummy().setBlockName("CamoDummy");
 		
-    	if (MalisisDoorsCompat.isCompatible())
-		{
-			MalisisDoorsCompat.preInit();
-		}
-		else
-		{
+        if (Loader.isModLoaded("malisisdoors") && MalisisDoorsCompat.isCompatible())
+        {
+            MalisisDoorsCompat.preInit();
+        }
+        else
+        {
             // TrapDoor
             camoTrapDoor = new BlockCamoTrapDoor().setBlockName("SecretTrapDoor");
 

--- a/src/main/java/com/github/abrarsyed/secretroomsmod/malisisdoors/MalisisDoorsCompat.java
+++ b/src/main/java/com/github/abrarsyed/secretroomsmod/malisisdoors/MalisisDoorsCompat.java
@@ -32,7 +32,6 @@ import net.minecraft.block.material.Material;
 import com.github.abrarsyed.secretroomsmod.common.SecretRooms;
 
 import cpw.mods.fml.common.FMLCommonHandler;
-import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
 import cpw.mods.fml.relauncher.Side;
 
@@ -45,13 +44,8 @@ public class MalisisDoorsCompat
 
 	public static boolean isCompatible()
 	{
-		if (!Loader.isModLoaded("malisisdoors"))
-			return false;
+		return MalisisDoors.version.startsWith("1.7.10-1.3") || MalisisDoors.version.startsWith("1.7.10-1.4");
 
-		if (!MalisisDoors.version.startsWith("1.7.10-1.3."))
-			return false;
-
-		return true;
 	}
 
 	public static void preInit()


### PR DESCRIPTION
There is still a slight issue : 
java.lang.ClassCastException: com.github.abrarsyed.secretroomsmod.malisisdoors.CamoDoorTileEntity cannot be cast to com.github.abrarsyed.secretroomsmod.blocks.TileEntityCamo

This will happen if you load a world with Secret Doors already placed in, and try to add or remove MalisisDoors.