### PR TITLE
Make sure to delete the GL resources from the "old" RenderChunk, too

### DIFF
--- a/src/main/java/com/wynprice/secretroomsmod/render/FakeRenderChunk.java
+++ b/src/main/java/com/wynprice/secretroomsmod/render/FakeRenderChunk.java
@@ -52,6 +52,12 @@ public class FakeRenderChunk extends ListedRenderChunk
 		}
 		return super.createRegionRenderCache(world, from, to, subtract);
 	}
+
+	@Override
+	public void deleteGlResources() {
+		super.deleteGlResources();
+		this.oldRender.deleteGlResources();
+	}
 	
 	@Override
 	public void rebuildChunk(float x, float y, float z, ChunkCompileTaskGenerator generator) 


### PR DESCRIPTION
It didn't properly free up resources before. This fixes that.

Bumps down load times for join / change dimension by a ton.

Fixes #216 